### PR TITLE
Remove unnecessary require vendor/autoload

### DIFF
--- a/src/StatusioClient.php
+++ b/src/StatusioClient.php
@@ -2,8 +2,6 @@
 
 namespace Statusio;
 
-require 'vendor/autoload.php';
-
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception;
 


### PR DESCRIPTION
psr-4 autloading is accomplished in the composer.json file.
this require is unnecessary.